### PR TITLE
Fix ERR_UNKNOWN_URL_SCHEME error

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
         secure: false,
         realTime: true
       }, _.get(config, 'horizon', {}));
-      var protocol = horizonConfig.secure ? 'https://' : 'http';
+      var protocol = horizonConfig.secure ? 'https://' : 'http://';
       return '<script id="client-driver" src="' + protocol + horizonConfig.host + '/horizon/horizon.js"></script>';
     }
   }


### PR DESCRIPTION
Without this change, I get `GET httplocalhost:8181/horizon/horizon.js net::ERR_UNKNOWN_URL_SCHEME` from chrome when loading the app in development.